### PR TITLE
Add basic allocator test with Makefile test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,10 @@ SRCS = main.cpp
 HEADERS = memory_allocator.h
 BUILD_DIR = build
 
-.PHONY: all clean debug release
+TEST_TARGET = allocator_basic_test
+TEST_SRCS = tests/allocator_basic_test.cpp
+
+.PHONY: all clean debug release test
 
 all: release
 
@@ -22,6 +25,11 @@ release: $(BUILD_DIR)
 debug: CXXFLAGS += $(DEBUG_FLAGS)
 debug: $(BUILD_DIR)
 	$(CXX) $(CXXFLAGS) $(SRCS) -o $(BUILD_DIR)/$(TARGET)_debug
+
+test: CXXFLAGS += $(DEBUG_FLAGS)
+test: $(BUILD_DIR)
+	$(CXX) $(CXXFLAGS) -I. $(TEST_SRCS) -o $(BUILD_DIR)/$(TEST_TARGET)
+	$(BUILD_DIR)/$(TEST_TARGET)
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/tests/allocator_basic_test.cpp
+++ b/tests/allocator_basic_test.cpp
@@ -1,0 +1,16 @@
+#include "../memory_allocator.h"
+#include <cassert>
+#include <iostream>
+
+int main() {
+    FancyPerThreadAllocator alloc(1024 * 1024); // 1MB arena
+    void* ptr = alloc.allocate(128);
+    assert(ptr != nullptr);
+    alloc.deallocate(ptr);
+
+    AllocStatsSnapshot snap = alloc.getStatsSnapshot();
+    assert(snap.currentUsedBytes == 0);
+
+    std::cout << "Basic allocation test passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- create `tests/allocator_basic_test.cpp` that allocates and frees memory
- add a `test` target to Makefile to build and run the new test

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6843dfb26080832e8f8d36892edce70a