### PR TITLE
Fix README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ A sample Makefile is provided. To compile:
 
 ```bash
 make
-./memory_allocator_test
+./build/memory_allocator_test
 
 example output:
-./build/memory_allocator_test 
+./build/memory_allocator_test
 
 === Compare System Malloc vs. Fancy(Off) vs. Fancy(On) under HPC ephemeral scenario ===
 Threads= 512, Ops/Thread= 1000000, ringSize= 500000
@@ -85,3 +85,4 @@ Elapsed (us): 41289834
 Alloc calls : 352295903, Free calls: 216814382, Peak usage: 36793754057
 
 All tests completed.
+```


### PR DESCRIPTION
## Summary
- fix open-ended bash code block
- instruct user to run `./build/memory_allocator_test` after build

## Testing
- `make clean && make && ./build/memory_allocator_test` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_6843dfae3384832ea683063ab9d2087f