### PR TITLE
Fix allocator magic check

### DIFF
--- a/memory_allocator.h
+++ b/memory_allocator.h
@@ -460,11 +460,11 @@ public:
 
     void deallocate(void* ptr) {
         if(!ptr) return;
-        // read the last 4 bytes to see if magic
-        char* p = (char*)ptr - 4;
-        uint32_t mg = *(uint32_t*)p;
+        // look at the arena block header preceding the pointer
+        char* headerStart = (char*)ptr - sizeof(Arena::BlockHeader);
+        auto* hdr = reinterpret_cast<Arena::BlockHeader*>(headerStart);
         auto* tld=getThreadData();
-        if(mg==Arena::MAGIC){
+        if(hdr->magic==Arena::MAGIC){
             tld->arena->deallocate(ptr, stats_);
         } else {
             tld->smallCache.freeSmall(ptr, stats_);


### PR DESCRIPTION
## Summary
- determine the arena header at deallocation time
- check `Arena::BlockHeader::magic` to select arena or small cache

## Testing
- `make release`
- `./build/memory_allocator_test` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_6843dfa9ab64832ea53ddea27d714587